### PR TITLE
Return 404 to avoid error client side

### DIFF
--- a/app/Controllers/Http/StaticController.js
+++ b/app/Controllers/Http/StaticController.js
@@ -217,7 +217,7 @@ class StaticController {
   announcement({
     response,
   }) {
-    return response.send('No announcement found.');
+    return response.status(404).send('No announcement found.');
   }
 }
 


### PR DESCRIPTION
Fixes `Uncaught (in promise) SyntaxError: Unexpected token N in JSON at position 0`